### PR TITLE
refactor!: use `ResolvedInputSource` downstream of `InputContent`

### DIFF
--- a/lychee-bin/src/commands/check.rs
+++ b/lychee-bin/src/commands/check.rs
@@ -398,7 +398,7 @@ mod tests {
     use crate::{formatters::get_response_formatter, options};
     use http::StatusCode;
     use log::info;
-    use lychee_lib::{CacheStatus, ClientBuilder, ErrorKind, InputSource, Uri};
+    use lychee_lib::{CacheStatus, ClientBuilder, ErrorKind, ResolvedInputSource, Uri};
 
     use super::*;
 
@@ -408,7 +408,7 @@ mod tests {
         let response = Response::new(
             Uri::try_from("http://127.0.0.1").unwrap(),
             Status::Cached(CacheStatus::Ok(200)),
-            InputSource::Stdin,
+            ResolvedInputSource::Stdin,
         );
         let formatter = get_response_formatter(&options::OutputMode::Plain);
         show_progress(
@@ -430,7 +430,7 @@ mod tests {
         let response = Response::new(
             Uri::try_from("http://127.0.0.1").unwrap(),
             Status::Cached(CacheStatus::Ok(200)),
-            InputSource::Stdin,
+            ResolvedInputSource::Stdin,
         );
         let formatter = get_response_formatter(&options::OutputMode::Plain);
         show_progress(

--- a/lychee-bin/src/commands/check.rs
+++ b/lychee-bin/src/commands/check.rs
@@ -12,7 +12,7 @@ use tokio_stream::wrappers::ReceiverStream;
 
 use lychee_lib::archive::Archive;
 use lychee_lib::{Client, ErrorKind, Request, Response, Uri};
-use lychee_lib::{InputSource, Result};
+use lychee_lib::{InputSource, ResolvedInputSource, Result};
 use lychee_lib::{ResponseBody, Status};
 
 use crate::formatters::get_response_formatter;
@@ -372,7 +372,7 @@ fn show_progress(
     Ok(())
 }
 
-fn get_failed_urls(stats: &mut ResponseStats) -> Vec<(InputSource, Url)> {
+fn get_failed_urls(stats: &mut ResponseStats) -> Vec<(ResolvedInputSource, Url)> {
     stats
         .error_map
         .iter()

--- a/lychee-bin/src/commands/check.rs
+++ b/lychee-bin/src/commands/check.rs
@@ -12,7 +12,7 @@ use tokio_stream::wrappers::ReceiverStream;
 
 use lychee_lib::archive::Archive;
 use lychee_lib::{Client, ErrorKind, Request, Response, Uri};
-use lychee_lib::{InputSource, ResolvedInputSource, Result};
+use lychee_lib::{InputSource, Result};
 use lychee_lib::{ResponseBody, Status};
 
 use crate::formatters::get_response_formatter;
@@ -372,7 +372,7 @@ fn show_progress(
     Ok(())
 }
 
-fn get_failed_urls(stats: &mut ResponseStats) -> Vec<(ResolvedInputSource, Url)> {
+fn get_failed_urls(stats: &mut ResponseStats) -> Vec<(InputSource, Url)> {
     stats
         .error_map
         .iter()

--- a/lychee-bin/src/formatters/stats/compact.rs
+++ b/lychee-bin/src/formatters/stats/compact.rs
@@ -124,7 +124,7 @@ mod tests {
     use crate::formatters::stats::StatsFormatter;
     use crate::{options::OutputMode, stats::ResponseStats};
     use http::StatusCode;
-    use lychee_lib::{InputSource, ResolvedInputSource, ResponseBody, Status, Uri};
+    use lychee_lib::{InputSource, ResponseBody, Status, Uri};
     use std::collections::{HashMap, HashSet};
     use url::Url;
 
@@ -133,10 +133,10 @@ mod tests {
     #[test]
     fn test_formatter() {
         // A couple of dummy successes
-        let mut success_map: HashMap<ResolvedInputSource, HashSet<ResponseBody>> = HashMap::new();
+        let mut success_map: HashMap<InputSource, HashSet<ResponseBody>> = HashMap::new();
 
         success_map.insert(
-            ResolvedInputSource::RemoteUrl(Box::new(Url::parse("https://example.com").unwrap())),
+            InputSource::RemoteUrl(Box::new(Url::parse("https://example.com").unwrap())),
             HashSet::from_iter(vec![ResponseBody {
                 uri: Uri::from(Url::parse("https://example.com").unwrap()),
                 status: Status::Ok(StatusCode::OK),
@@ -153,8 +153,8 @@ mod tests {
             status: Status::Ok(StatusCode::INTERNAL_SERVER_ERROR),
         };
 
-        let mut error_map: HashMap<ResolvedInputSource, HashSet<ResponseBody>> = HashMap::new();
-        let source = ResolvedInputSource::RemoteUrl(Box::new(Url::parse("https://example.com").unwrap()));
+        let mut error_map: HashMap<InputSource, HashSet<ResponseBody>> = HashMap::new();
+        let source = InputSource::RemoteUrl(Box::new(Url::parse("https://example.com").unwrap()));
         error_map.insert(source, HashSet::from_iter(vec![err1, err2]));
 
         let stats = ResponseStats {

--- a/lychee-bin/src/formatters/stats/compact.rs
+++ b/lychee-bin/src/formatters/stats/compact.rs
@@ -124,7 +124,7 @@ mod tests {
     use crate::formatters::stats::StatsFormatter;
     use crate::{options::OutputMode, stats::ResponseStats};
     use http::StatusCode;
-    use lychee_lib::{InputSource, ResponseBody, Status, Uri};
+    use lychee_lib::{InputSource, ResolvedInputSource, ResponseBody, Status, Uri};
     use std::collections::{HashMap, HashSet};
     use url::Url;
 
@@ -133,10 +133,10 @@ mod tests {
     #[test]
     fn test_formatter() {
         // A couple of dummy successes
-        let mut success_map: HashMap<InputSource, HashSet<ResponseBody>> = HashMap::new();
+        let mut success_map: HashMap<ResolvedInputSource, HashSet<ResponseBody>> = HashMap::new();
 
         success_map.insert(
-            InputSource::RemoteUrl(Box::new(Url::parse("https://example.com").unwrap())),
+            ResolvedInputSource::RemoteUrl(Box::new(Url::parse("https://example.com").unwrap())),
             HashSet::from_iter(vec![ResponseBody {
                 uri: Uri::from(Url::parse("https://example.com").unwrap()),
                 status: Status::Ok(StatusCode::OK),
@@ -153,8 +153,8 @@ mod tests {
             status: Status::Ok(StatusCode::INTERNAL_SERVER_ERROR),
         };
 
-        let mut error_map: HashMap<InputSource, HashSet<ResponseBody>> = HashMap::new();
-        let source = InputSource::RemoteUrl(Box::new(Url::parse("https://example.com").unwrap()));
+        let mut error_map: HashMap<ResolvedInputSource, HashSet<ResponseBody>> = HashMap::new();
+        let source = ResolvedInputSource::RemoteUrl(Box::new(Url::parse("https://example.com").unwrap()));
         error_map.insert(source, HashSet::from_iter(vec![err1, err2]));
 
         let stats = ResponseStats {

--- a/lychee-bin/src/formatters/stats/markdown.rs
+++ b/lychee-bin/src/formatters/stats/markdown.rs
@@ -6,7 +6,7 @@ use std::{
 use super::StatsFormatter;
 use anyhow::Result;
 use http::StatusCode;
-use lychee_lib::{InputSource, ResolvedInputSource, ResponseBody, Status};
+use lychee_lib::{InputSource, ResponseBody, Status};
 use std::fmt::Write;
 use tabled::{
     Table, Tabled,
@@ -121,7 +121,7 @@ impl Display for MarkdownResponseStats {
 fn write_stats_per_input<T, F>(
     f: &mut fmt::Formatter<'_>,
     name: &'static str,
-    map: &HashMap<ResolvedInputSource, HashSet<T>>,
+    map: &HashMap<InputSource, HashSet<T>>,
     write_stat: F,
 ) -> fmt::Result
 where

--- a/lychee-bin/src/formatters/stats/markdown.rs
+++ b/lychee-bin/src/formatters/stats/markdown.rs
@@ -6,7 +6,7 @@ use std::{
 use super::StatsFormatter;
 use anyhow::Result;
 use http::StatusCode;
-use lychee_lib::{InputSource, ResponseBody, Status};
+use lychee_lib::{InputSource, ResolvedInputSource, ResponseBody, Status};
 use std::fmt::Write;
 use tabled::{
     Table, Tabled,
@@ -121,7 +121,7 @@ impl Display for MarkdownResponseStats {
 fn write_stats_per_input<T, F>(
     f: &mut fmt::Formatter<'_>,
     name: &'static str,
-    map: &HashMap<InputSource, HashSet<T>>,
+    map: &HashMap<ResolvedInputSource, HashSet<T>>,
     write_stat: F,
 ) -> fmt::Result
 where

--- a/lychee-bin/src/formatters/stats/markdown.rs
+++ b/lychee-bin/src/formatters/stats/markdown.rs
@@ -159,7 +159,9 @@ impl StatsFormatter for Markdown {
 #[cfg(test)]
 mod tests {
     use http::StatusCode;
-    use lychee_lib::{CacheStatus, InputSource, Response, ResponseBody, Status, Uri};
+    use lychee_lib::{
+        CacheStatus, InputSource, ResolvedInputSource, Response, ResponseBody, Status, Uri,
+    };
     use reqwest::Url;
 
     use crate::formatters::suggestion::Suggestion;
@@ -219,7 +221,7 @@ mod tests {
         let response = Response::new(
             Uri::try_from("http://127.0.0.1").unwrap(),
             Status::Cached(CacheStatus::Error(Some(404))),
-            InputSource::Stdin,
+            ResolvedInputSource::Stdin,
         );
         stats.add(response);
         stats

--- a/lychee-bin/src/formatters/stats/mod.rs
+++ b/lychee-bin/src/formatters/stats/mod.rs
@@ -55,14 +55,14 @@ where
 mod tests {
     use super::*;
 
-    use lychee_lib::{ErrorKind, Response, Status, Uri};
+    use lychee_lib::{ErrorKind, ResolvedInputSource, Response, Status, Uri};
     use url::Url;
 
     fn make_test_url(url: &str) -> Url {
         Url::parse(url).expect("Expected valid Website URI")
     }
 
-    fn make_test_response(url_str: &str, source: InputSource) -> Response {
+    fn make_test_response(url_str: &str, source: ResolvedInputSource) -> Response {
         let uri = Uri::from(make_test_url(url_str));
 
         Response::new(uri, Status::Error(ErrorKind::TestError), source)
@@ -74,11 +74,17 @@ mod tests {
 
         // Sorted list of test sources
         let test_sources = vec![
-            InputSource::RemoteUrl(Box::new(make_test_url("https://example.com/404"))),
-            InputSource::RemoteUrl(Box::new(make_test_url("https://example.com/home"))),
-            InputSource::RemoteUrl(Box::new(make_test_url("https://example.com/page/1"))),
-            InputSource::RemoteUrl(Box::new(make_test_url("https://example.com/page/10"))),
+            ResolvedInputSource::RemoteUrl(Box::new(make_test_url("https://example.com/404"))),
+            ResolvedInputSource::RemoteUrl(Box::new(make_test_url("https://example.com/home"))),
+            ResolvedInputSource::RemoteUrl(Box::new(make_test_url("https://example.com/page/1"))),
+            ResolvedInputSource::RemoteUrl(Box::new(make_test_url("https://example.com/page/10"))),
         ];
+
+        let unresolved_test_sources: Vec<InputSource> = test_sources
+            .iter()
+            .map(Clone::clone)
+            .map(Into::<InputSource>::into)
+            .collect();
 
         // Sorted list of test responses
         let test_response_urls = vec![
@@ -104,7 +110,7 @@ mod tests {
             .collect();
 
         // Check that the input sources are sorted
-        assert_eq!(test_sources, sorted_sources);
+        assert_eq!(unresolved_test_sources, sorted_sources);
 
         // Check that the responses are sorted
         for (_, response_bodies) in sorted_errors {

--- a/lychee-bin/src/formatters/stats/mod.rs
+++ b/lychee-bin/src/formatters/stats/mod.rs
@@ -18,7 +18,6 @@ use std::{
 use crate::stats::ResponseStats;
 use anyhow::Result;
 use lychee_lib::InputSource;
-use lychee_lib::ResolvedInputSource;
 
 pub(crate) trait StatsFormatter {
     /// Format the stats of all responses and write them to stdout
@@ -27,7 +26,7 @@ pub(crate) trait StatsFormatter {
 
 /// Convert a `ResponseStats` `HashMap` to a sorted Vec of key-value pairs
 /// The returned keys and values are both sorted in natural, case-insensitive order
-fn sort_stat_map<T>(stat_map: &HashMap<ResolvedInputSource, HashSet<T>>) -> Vec<(&ResolvedInputSource, Vec<&T>)>
+fn sort_stat_map<T>(stat_map: &HashMap<InputSource, HashSet<T>>) -> Vec<(&InputSource, Vec<&T>)>
 where
     T: Display,
 {

--- a/lychee-bin/src/formatters/stats/mod.rs
+++ b/lychee-bin/src/formatters/stats/mod.rs
@@ -18,6 +18,7 @@ use std::{
 use crate::stats::ResponseStats;
 use anyhow::Result;
 use lychee_lib::InputSource;
+use lychee_lib::ResolvedInputSource;
 
 pub(crate) trait StatsFormatter {
     /// Format the stats of all responses and write them to stdout
@@ -26,7 +27,7 @@ pub(crate) trait StatsFormatter {
 
 /// Convert a `ResponseStats` `HashMap` to a sorted Vec of key-value pairs
 /// The returned keys and values are both sorted in natural, case-insensitive order
-fn sort_stat_map<T>(stat_map: &HashMap<InputSource, HashSet<T>>) -> Vec<(&InputSource, Vec<&T>)>
+fn sort_stat_map<T>(stat_map: &HashMap<ResolvedInputSource, HashSet<T>>) -> Vec<(&ResolvedInputSource, Vec<&T>)>
 where
     T: Display,
 {

--- a/lychee-bin/src/stats.rs
+++ b/lychee-bin/src/stats.rs
@@ -90,7 +90,7 @@ impl ResponseStats {
     /// Add a response status to the appropriate map (success, fail, excluded)
     fn add_response_status(&mut self, response: Response) {
         let status = response.status();
-        let source = response.source().clone();
+        let source: InputSource = response.source().clone().into();
         let status_map_entry = match status {
             _ if status.is_error() => self.error_map.entry(source).or_default(),
             Status::Ok(_) if self.detailed_stats => self.success_map.entry(source).or_default(),

--- a/lychee-bin/src/stats.rs
+++ b/lychee-bin/src/stats.rs
@@ -126,7 +126,9 @@ mod tests {
     use std::collections::{HashMap, HashSet};
 
     use http::StatusCode;
-    use lychee_lib::{ErrorKind, InputSource, Response, ResponseBody, Status, Uri};
+    use lychee_lib::{
+        ErrorKind, InputSource, ResolvedInputSource, Response, ResponseBody, Status, Uri,
+    };
     use reqwest::Url;
 
     use super::ResponseStats;
@@ -140,7 +142,7 @@ mod tests {
     // and it's a lot faster to just generate a fake response
     fn mock_response(status: Status) -> Response {
         let uri = website("https://some-url.com/ok");
-        Response::new(uri, status, InputSource::Stdin)
+        Response::new(uri, status, ResolvedInputSource::Stdin)
     }
 
     fn dummy_ok() -> Response {
@@ -176,7 +178,10 @@ mod tests {
 
         let response = dummy_error();
         let expected_error_map: HashMap<InputSource, HashSet<ResponseBody>> =
-            HashMap::from_iter([(response.source().clone(), HashSet::from_iter([response.1]))]);
+            HashMap::from_iter([(
+                response.source().clone().into(),
+                HashSet::from_iter([response.1]),
+            )]);
         assert_eq!(stats.error_map, expected_error_map);
 
         assert!(stats.success_map.is_empty());
@@ -196,7 +201,7 @@ mod tests {
         let mut expected_error_map: HashMap<InputSource, HashSet<ResponseBody>> = HashMap::new();
         let response = dummy_error();
         let entry = expected_error_map
-            .entry(response.source().clone())
+            .entry(response.source().clone().into())
             .or_default();
         entry.insert(response.1);
         assert_eq!(stats.error_map, expected_error_map);
@@ -204,7 +209,7 @@ mod tests {
         let mut expected_success_map: HashMap<InputSource, HashSet<ResponseBody>> = HashMap::new();
         let response = dummy_ok();
         let entry = expected_success_map
-            .entry(response.source().clone())
+            .entry(response.source().clone().into())
             .or_default();
         entry.insert(response.1);
         assert_eq!(stats.success_map, expected_success_map);
@@ -212,7 +217,7 @@ mod tests {
         let mut expected_excluded_map: HashMap<InputSource, HashSet<ResponseBody>> = HashMap::new();
         let response = dummy_excluded();
         let entry = expected_excluded_map
-            .entry(response.source().clone())
+            .entry(response.source().clone().into())
             .or_default();
         entry.insert(response.1);
         assert_eq!(stats.excluded_map, expected_excluded_map);

--- a/lychee-bin/src/stats.rs
+++ b/lychee-bin/src/stats.rs
@@ -3,7 +3,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use lychee_lib::{CacheStatus, InputSource, Response, ResponseBody, Status};
+use lychee_lib::{CacheStatus, InputSource, ResolvedInputSource, Response, ResponseBody, Status};
 use serde::Serialize;
 
 use crate::formatters::suggestion::Suggestion;
@@ -38,13 +38,13 @@ pub(crate) struct ResponseStats {
     /// Number of responses that were cached from a previous run
     pub(crate) cached: usize,
     /// Map to store successful responses (if `detailed_stats` is enabled)
-    pub(crate) success_map: HashMap<InputSource, HashSet<ResponseBody>>,
+    pub(crate) success_map: HashMap<ResolvedInputSource, HashSet<ResponseBody>>,
     /// Map to store failed responses (if `detailed_stats` is enabled)
-    pub(crate) error_map: HashMap<InputSource, HashSet<ResponseBody>>,
+    pub(crate) error_map: HashMap<ResolvedInputSource, HashSet<ResponseBody>>,
     /// Replacement suggestions for failed responses (if `--suggest` is enabled)
-    pub(crate) suggestion_map: HashMap<InputSource, HashSet<Suggestion>>,
+    pub(crate) suggestion_map: HashMap<ResolvedInputSource, HashSet<Suggestion>>,
     /// Map to store excluded responses (if `detailed_stats` is enabled)
-    pub(crate) excluded_map: HashMap<InputSource, HashSet<ResponseBody>>,
+    pub(crate) excluded_map: HashMap<ResolvedInputSource, HashSet<ResponseBody>>,
     /// Used to store the duration of the run in seconds.
     pub(crate) duration_secs: u64,
     /// Also track successful and excluded responses
@@ -90,7 +90,7 @@ impl ResponseStats {
     /// Add a response status to the appropriate map (success, fail, excluded)
     fn add_response_status(&mut self, response: Response) {
         let status = response.status();
-        let source: InputSource = response.source().clone().into();
+        let source = response.source().clone();
         let status_map_entry = match status {
             _ if status.is_error() => self.error_map.entry(source).or_default(),
             Status::Ok(_) if self.detailed_stats => self.success_map.entry(source).or_default(),
@@ -177,9 +177,9 @@ mod tests {
         stats.add(dummy_ok());
 
         let response = dummy_error();
-        let expected_error_map: HashMap<InputSource, HashSet<ResponseBody>> =
+        let expected_error_map: HashMap<ResolvedInputSource, HashSet<ResponseBody>> =
             HashMap::from_iter([(
-                response.source().clone().into(),
+                response.source().clone(),
                 HashSet::from_iter([response.1]),
             )]);
         assert_eq!(stats.error_map, expected_error_map);
@@ -198,26 +198,26 @@ mod tests {
         stats.add(dummy_excluded());
         stats.add(dummy_ok());
 
-        let mut expected_error_map: HashMap<InputSource, HashSet<ResponseBody>> = HashMap::new();
+        let mut expected_error_map: HashMap<ResolvedInputSource, HashSet<ResponseBody>> = HashMap::new();
         let response = dummy_error();
         let entry = expected_error_map
-            .entry(response.source().clone().into())
+            .entry(response.source().clone())
             .or_default();
         entry.insert(response.1);
         assert_eq!(stats.error_map, expected_error_map);
 
-        let mut expected_success_map: HashMap<InputSource, HashSet<ResponseBody>> = HashMap::new();
+        let mut expected_success_map: HashMap<ResolvedInputSource, HashSet<ResponseBody>> = HashMap::new();
         let response = dummy_ok();
         let entry = expected_success_map
-            .entry(response.source().clone().into())
+            .entry(response.source().clone())
             .or_default();
         entry.insert(response.1);
         assert_eq!(stats.success_map, expected_success_map);
 
-        let mut expected_excluded_map: HashMap<InputSource, HashSet<ResponseBody>> = HashMap::new();
+        let mut expected_excluded_map: HashMap<ResolvedInputSource, HashSet<ResponseBody>> = HashMap::new();
         let response = dummy_excluded();
         let entry = expected_excluded_map
-            .entry(response.source().clone().into())
+            .entry(response.source().clone())
             .or_default();
         entry.insert(response.1);
         assert_eq!(stats.excluded_map, expected_excluded_map);

--- a/lychee-lib/src/extract/mod.rs
+++ b/lychee-lib/src/extract/mod.rs
@@ -71,7 +71,7 @@ mod tests {
     use crate::{
         Uri,
         test_utils::{load_fixture, mail, website},
-        types::{FileType, InputContent, InputSource, ResolvedInputSource},
+        types::{FileType, InputContent, ResolvedInputSource},
         utils::url::find_links,
     };
 

--- a/lychee-lib/src/extract/mod.rs
+++ b/lychee-lib/src/extract/mod.rs
@@ -71,7 +71,7 @@ mod tests {
     use crate::{
         Uri,
         test_utils::{load_fixture, mail, website},
-        types::{FileType, InputContent, InputSource},
+        types::{FileType, InputContent, InputSource, ResolvedInputSource},
         utils::url::find_links,
     };
 
@@ -204,7 +204,7 @@ mod tests {
 
     #[test]
     fn test_extract_relative_url() {
-        let source = InputSource::RemoteUrl(Box::new(
+        let source = ResolvedInputSource::RemoteUrl(Box::new(
             Url::parse("https://example.com/some-post").unwrap(),
         ));
 

--- a/lychee-lib/src/lib.rs
+++ b/lychee-lib/src/lib.rs
@@ -100,7 +100,7 @@ pub use crate::{
     types::{
         AcceptRange, AcceptRangeError, Base, BasicAuthCredentials, BasicAuthSelector, CacheStatus,
         CookieJar, ErrorKind, FileExtensions, FileType, Input, InputContent, InputResolver,
-        InputSource, Request, Response, ResponseBody, Result, Status, StatusCodeExcluder,
-        StatusCodeSelector, uri::valid::Uri,
+        InputSource, Request, ResolvedInputSource, Response, ResponseBody, Result, Status,
+        StatusCodeExcluder, StatusCodeSelector, uri::valid::Uri,
     },
 };

--- a/lychee-lib/src/types/base.rs
+++ b/lychee-lib/src/types/base.rs
@@ -2,7 +2,7 @@ use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use std::{convert::TryFrom, path::PathBuf};
 
-use crate::{ErrorKind, InputSource};
+use crate::{ErrorKind, ResolvedInputSource};
 
 /// When encountering links without a full domain in a document,
 /// the base determines where this resource can be found.
@@ -30,9 +30,9 @@ impl Base {
         }
     }
 
-    pub(crate) fn from_source(source: &InputSource) -> Option<Base> {
+    pub(crate) fn from_source(source: &ResolvedInputSource) -> Option<Base> {
         match &source {
-            InputSource::RemoteUrl(url) => {
+            ResolvedInputSource::RemoteUrl(url) => {
                 // Create a new URL with just the scheme, host, and port
                 let mut base_url = url.clone();
                 base_url.set_path("");
@@ -124,7 +124,7 @@ mod test_base {
             ),
         ] {
             let url = Url::parse(url).unwrap();
-            let source = InputSource::RemoteUrl(Box::new(url.clone()));
+            let source = ResolvedInputSource::RemoteUrl(Box::new(url.clone()));
             let base = Base::from_source(&source);
             let expected = Base::Remote(Url::parse(expected).unwrap());
             assert_eq!(base, Some(expected));

--- a/lychee-lib/src/types/input/content.rs
+++ b/lychee-lib/src/types/input/content.rs
@@ -4,6 +4,7 @@
 //! input sources, along with metadata about the source and file type.
 
 use super::source::InputSource;
+use super::source::ResolvedInputSource;
 use crate::ErrorKind;
 use crate::types::FileType;
 use std::fs;
@@ -13,7 +14,7 @@ use std::path::PathBuf;
 #[derive(Debug)]
 pub struct InputContent {
     /// Input source
-    pub source: InputSource,
+    pub source: ResolvedInputSource,
     /// File type of given input
     pub file_type: FileType,
     /// Raw UTF-8 string content
@@ -26,7 +27,7 @@ impl InputContent {
     pub fn from_string(s: &str, file_type: FileType) -> Self {
         // TODO: consider using Cow (to avoid one .clone() for String types)
         Self {
-            source: InputSource::String(s.to_owned()),
+            source: ResolvedInputSource::String(s.to_owned()),
             file_type,
             content: s.to_owned(),
         }
@@ -50,7 +51,7 @@ impl TryFrom<&PathBuf> for InputContent {
         };
 
         Ok(Self {
-            source: InputSource::String(input.clone()),
+            source: ResolvedInputSource::String(input.clone()),
             file_type: FileType::from(path),
             content: input,
         })

--- a/lychee-lib/src/types/input/content.rs
+++ b/lychee-lib/src/types/input/content.rs
@@ -3,7 +3,6 @@
 //! The `InputContent` type represents the actual content extracted from various
 //! input sources, along with metadata about the source and file type.
 
-use super::source::InputSource;
 use super::source::ResolvedInputSource;
 use crate::ErrorKind;
 use crate::types::FileType;

--- a/lychee-lib/src/types/input/input.rs
+++ b/lychee-lib/src/types/input/input.rs
@@ -417,7 +417,7 @@ mod tests {
         assert!(matches!(
             input,
             Ok(Input {
-                source: ResolvedInputSource::FsPath(PathBuf { .. }),
+                source: InputSource::FsPath(PathBuf { .. }),
                 file_type_hint: None,
             })
         ));

--- a/lychee-lib/src/types/input/input.rs
+++ b/lychee-lib/src/types/input/input.rs
@@ -206,7 +206,7 @@ impl Input {
                 match source_result {
                     Ok(source) => {
                         let content_result = match source {
-                            ResolvedInputSource::FsPath(path) => {
+                            ResolvedInputSource::FsPath(path, _) => {
                                 Self::path_content(&path).await
                             },
                             ResolvedInputSource::RemoteUrl(url) => {
@@ -353,7 +353,7 @@ impl Input {
 
         let input_content = InputContent {
             file_type: FileType::from(&path),
-            source: InputSource::FsPath(path),
+            source: ResolvedInputSource::FsPath(path, None),
             content,
         };
 
@@ -371,7 +371,7 @@ impl Input {
         stdin.read_to_string(&mut content).await?;
 
         let input_content = InputContent {
-            source: InputSource::Stdin,
+            source: ResolvedInputSource::Stdin,
             file_type: file_type_hint.unwrap_or_default(),
             content,
         };
@@ -417,7 +417,7 @@ mod tests {
         assert!(matches!(
             input,
             Ok(Input {
-                source: InputSource::FsPath(PathBuf { .. }),
+                source: ResolvedInputSource::FsPath(PathBuf { .. }),
                 file_type_hint: None,
             })
         ));

--- a/lychee-lib/src/types/input/input.rs
+++ b/lychee-lib/src/types/input/input.rs
@@ -206,7 +206,7 @@ impl Input {
                 match source_result {
                     Ok(source) => {
                         let content_result = match source {
-                            ResolvedInputSource::FsPath(path, _) => {
+                            ResolvedInputSource::FsPath(path) => {
                                 Self::path_content(&path).await
                             },
                             ResolvedInputSource::RemoteUrl(url) => {
@@ -353,7 +353,7 @@ impl Input {
 
         let input_content = InputContent {
             file_type: FileType::from(&path),
-            source: ResolvedInputSource::FsPath(path, None),
+            source: ResolvedInputSource::FsPath(path),
             content,
         };
 

--- a/lychee-lib/src/types/input/mod.rs
+++ b/lychee-lib/src/types/input/mod.rs
@@ -33,3 +33,4 @@ pub use content::InputContent;
 pub use input::Input;
 pub use resolver::InputResolver;
 pub use source::InputSource;
+pub use source::ResolvedInputSource;

--- a/lychee-lib/src/types/input/resolver.rs
+++ b/lychee-lib/src/types/input/resolver.rs
@@ -93,7 +93,7 @@ impl InputResolver {
                                 // Instead, we always check files captured by
                                 // the glob pattern, as the user explicitly
                                 // specified them.
-                                yield ResolvedInputSource::FsPath(path);
+                                yield ResolvedInputSource::FsPath(path, Some((pattern.clone(), *ignore_case)));
                             }
                             Err(e) => {
                                 eprintln!("Error in glob pattern: {e:?}");
@@ -131,7 +131,7 @@ impl InputResolver {
                                 }
                             }
 
-                            yield ResolvedInputSource::FsPath(entry.path().to_path_buf());
+                            yield ResolvedInputSource::FsPath(entry.path().to_path_buf(), None);
                         }
                     } else {
                         // For individual files, yield if not excluded.
@@ -144,7 +144,7 @@ impl InputResolver {
                         // the user explicitly specified the file, so they
                         // expect it to be checked.
                         if !excluded_paths.is_match(&path.to_string_lossy()) {
-                            yield ResolvedInputSource::FsPath(path.clone());
+                            yield ResolvedInputSource::FsPath(path.clone(), None);
                         }
                     }
                 },

--- a/lychee-lib/src/types/input/resolver.rs
+++ b/lychee-lib/src/types/input/resolver.rs
@@ -93,7 +93,7 @@ impl InputResolver {
                                 // Instead, we always check files captured by
                                 // the glob pattern, as the user explicitly
                                 // specified them.
-                                yield ResolvedInputSource::FsPath(path, Some((pattern.clone(), *ignore_case)));
+                                yield ResolvedInputSource::FsPath(path);
                             }
                             Err(e) => {
                                 eprintln!("Error in glob pattern: {e:?}");
@@ -131,7 +131,7 @@ impl InputResolver {
                                 }
                             }
 
-                            yield ResolvedInputSource::FsPath(entry.path().to_path_buf(), None);
+                            yield ResolvedInputSource::FsPath(entry.path().to_path_buf());
                         }
                     } else {
                         // For individual files, yield if not excluded.
@@ -144,7 +144,7 @@ impl InputResolver {
                         // the user explicitly specified the file, so they
                         // expect it to be checked.
                         if !excluded_paths.is_match(&path.to_string_lossy()) {
-                            yield ResolvedInputSource::FsPath(path.clone(), None);
+                            yield ResolvedInputSource::FsPath(path.clone());
                         }
                     }
                 },

--- a/lychee-lib/src/types/input/source.rs
+++ b/lychee-lib/src/types/input/source.rs
@@ -53,7 +53,7 @@ pub enum ResolvedInputSource {
     /// URL (of HTTP/HTTPS scheme).
     RemoteUrl(Box<Url>),
     /// File path.
-    FsPath(PathBuf),
+    FsPath(PathBuf, Option<(String, bool)>),
     /// Standard Input.
     Stdin,
     /// Raw string input.
@@ -64,7 +64,8 @@ impl From<ResolvedInputSource> for InputSource {
     fn from(resolved: ResolvedInputSource) -> Self {
         match resolved {
             ResolvedInputSource::RemoteUrl(url) => InputSource::RemoteUrl(url),
-            ResolvedInputSource::FsPath(path) => InputSource::FsPath(path),
+            ResolvedInputSource::FsPath(path, None) => InputSource::FsPath(path),
+            ResolvedInputSource::FsPath(path, Some((pattern, ignore_case))) => InputSource::FsGlob {pattern, ignore_case},
             ResolvedInputSource::Stdin => InputSource::Stdin,
             ResolvedInputSource::String(s) => InputSource::String(s),
         }
@@ -75,7 +76,7 @@ impl Display for ResolvedInputSource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(match self {
             Self::RemoteUrl(url) => url.as_str(),
-            Self::FsPath(path) => path.to_str().unwrap_or_default(),
+            Self::FsPath(path, _) => path.to_str().unwrap_or_default(),
             Self::Stdin => "stdin",
             Self::String(s) => s,
         })

--- a/lychee-lib/src/types/input/source.rs
+++ b/lychee-lib/src/types/input/source.rs
@@ -54,9 +54,10 @@ pub enum ResolvedInputSource {
     RemoteUrl(Box<Url>),
     /// File path, possibly resolved from a [`InputSource::FsGlob`].
     ///
-    /// The [`Option`] field, if specified, records the `pattern`
-    /// and `ignore_case` of the [`InputSource::FsGlob`] which resolved
-    /// to this [`ResolvedInputSource::FsPath`].
+    /// The [`Option`] field, if specified, records the `pattern` and
+    /// `ignore_case` of the [`InputSource::FsGlob`] which resolved
+    /// to this `FsPath`. If not specified, this `FsPath` was previously
+    /// a [`InputSource::FsPath`].
     FsPath(PathBuf, Option<(String, bool)>),
     /// Standard Input.
     Stdin,

--- a/lychee-lib/src/types/input/source.rs
+++ b/lychee-lib/src/types/input/source.rs
@@ -52,13 +52,8 @@ pub enum InputSource {
 pub enum ResolvedInputSource {
     /// URL (of HTTP/HTTPS scheme).
     RemoteUrl(Box<Url>),
-    /// File path, possibly resolved from a [`InputSource::FsGlob`].
-    ///
-    /// The [`Option`] field, if specified, records the `pattern` and
-    /// `ignore_case` of the [`InputSource::FsGlob`] which resolved
-    /// to this `FsPath`. If not specified, this `FsPath` was previously
-    /// a [`InputSource::FsPath`].
-    FsPath(PathBuf, Option<(String, bool)>),
+    /// File path.
+    FsPath(PathBuf),
     /// Standard Input.
     Stdin,
     /// Raw string input.
@@ -69,13 +64,7 @@ impl From<ResolvedInputSource> for InputSource {
     fn from(resolved: ResolvedInputSource) -> Self {
         match resolved {
             ResolvedInputSource::RemoteUrl(url) => InputSource::RemoteUrl(url),
-            ResolvedInputSource::FsPath(path, None) => InputSource::FsPath(path),
-            ResolvedInputSource::FsPath(_path, Some((pattern, ignore_case))) => {
-                InputSource::FsGlob {
-                    pattern,
-                    ignore_case,
-                }
-            }
+            ResolvedInputSource::FsPath(path) => InputSource::FsPath(path),
             ResolvedInputSource::Stdin => InputSource::Stdin,
             ResolvedInputSource::String(s) => InputSource::String(s),
         }
@@ -86,7 +75,7 @@ impl Display for ResolvedInputSource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(match self {
             Self::RemoteUrl(url) => url.as_str(),
-            Self::FsPath(path, _) => path.to_str().unwrap_or_default(),
+            Self::FsPath(path) => path.to_str().unwrap_or_default(),
             Self::Stdin => "stdin",
             Self::String(s) => s,
         })

--- a/lychee-lib/src/types/input/source.rs
+++ b/lychee-lib/src/types/input/source.rs
@@ -52,7 +52,11 @@ pub enum InputSource {
 pub enum ResolvedInputSource {
     /// URL (of HTTP/HTTPS scheme).
     RemoteUrl(Box<Url>),
-    /// File path.
+    /// File path, possibly resolved from a [`InputSource::FsGlob`].
+    ///
+    /// The [`Option`] field, if specified, records the `pattern`
+    /// and `ignore_case` of the [`InputSource::FsGlob`] which resolved
+    /// to this [`ResolvedInputSource::FsPath`].
     FsPath(PathBuf, Option<(String, bool)>),
     /// Standard Input.
     Stdin,
@@ -65,7 +69,12 @@ impl From<ResolvedInputSource> for InputSource {
         match resolved {
             ResolvedInputSource::RemoteUrl(url) => InputSource::RemoteUrl(url),
             ResolvedInputSource::FsPath(path, None) => InputSource::FsPath(path),
-            ResolvedInputSource::FsPath(path, Some((pattern, ignore_case))) => InputSource::FsGlob {pattern, ignore_case},
+            ResolvedInputSource::FsPath(_path, Some((pattern, ignore_case))) => {
+                InputSource::FsGlob {
+                    pattern,
+                    ignore_case,
+                }
+            }
             ResolvedInputSource::Stdin => InputSource::Stdin,
             ResolvedInputSource::String(s) => InputSource::String(s),
         }

--- a/lychee-lib/src/types/mod.rs
+++ b/lychee-lib/src/types/mod.rs
@@ -23,7 +23,7 @@ pub use cache::CacheStatus;
 pub use cookies::CookieJar;
 pub use error::ErrorKind;
 pub use file::{FileExtensions, FileType};
-pub use input::{Input, InputContent, InputResolver, InputSource};
+pub use input::{Input, InputContent, InputResolver, InputSource, ResolvedInputSource};
 pub use request::Request;
 pub use response::{Response, ResponseBody};
 pub use status::Status;

--- a/lychee-lib/src/types/request.rs
+++ b/lychee-lib/src/types/request.rs
@@ -3,6 +3,7 @@ use std::{convert::TryFrom, fmt::Display};
 use crate::{BasicAuthCredentials, ErrorKind, Uri};
 
 use super::InputSource;
+use super::ResolvedInputSource;
 
 /// A request type that can be handle by lychee
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
@@ -12,7 +13,7 @@ pub struct Request {
     pub uri: Uri,
 
     /// The resource which contained the given URI
-    pub source: InputSource,
+    pub source: ResolvedInputSource,
 
     /// Specifies how the URI was rendered inside a document
     /// (for example `img`, `a`, `pre`, or `code`).
@@ -32,7 +33,7 @@ impl Request {
     #[must_use]
     pub const fn new(
         uri: Uri,
-        source: InputSource,
+        source: ResolvedInputSource,
         element: Option<String>,
         attribute: Option<String>,
         credentials: Option<BasicAuthCredentials>,
@@ -59,7 +60,7 @@ impl TryFrom<Uri> for Request {
     fn try_from(uri: Uri) -> Result<Self, Self::Error> {
         Ok(Request::new(
             uri.clone(),
-            InputSource::RemoteUrl(Box::new(uri.url)),
+            ResolvedInputSource::RemoteUrl(Box::new(uri.url)),
             None,
             None,
             None,
@@ -72,7 +73,7 @@ impl TryFrom<String> for Request {
 
     fn try_from(s: String) -> Result<Self, Self::Error> {
         let uri = Uri::try_from(s.as_str())?;
-        Ok(Request::new(uri, InputSource::String(s), None, None, None))
+        Ok(Request::new(uri, ResolvedInputSource::String(s), None, None, None))
     }
 }
 
@@ -83,7 +84,7 @@ impl TryFrom<&str> for Request {
         let uri = Uri::try_from(s)?;
         Ok(Request::new(
             uri,
-            InputSource::String(s.to_owned()),
+            ResolvedInputSource::String(s.to_owned()),
             None,
             None,
             None,

--- a/lychee-lib/src/types/request.rs
+++ b/lychee-lib/src/types/request.rs
@@ -2,7 +2,6 @@ use std::{convert::TryFrom, fmt::Display};
 
 use crate::{BasicAuthCredentials, ErrorKind, Uri};
 
-use super::InputSource;
 use super::ResolvedInputSource;
 
 /// A request type that can be handle by lychee
@@ -73,7 +72,13 @@ impl TryFrom<String> for Request {
 
     fn try_from(s: String) -> Result<Self, Self::Error> {
         let uri = Uri::try_from(s.as_str())?;
-        Ok(Request::new(uri, ResolvedInputSource::String(s), None, None, None))
+        Ok(Request::new(
+            uri,
+            ResolvedInputSource::String(s),
+            None,
+            None,
+            None,
+        ))
     }
 }
 

--- a/lychee-lib/src/types/resolver.rs
+++ b/lychee-lib/src/types/resolver.rs
@@ -3,6 +3,7 @@ use crate::utils::request;
 use crate::{BasicAuthExtractor, ErrorKind, Result, Uri};
 use http::HeaderMap;
 use reqwest::{Client, Request, Url};
+use crate::types::input::source::ResolvedInputSource;
 
 /// Structure to fetch remote content.
 #[derive(Debug, Default, Clone)]
@@ -33,7 +34,7 @@ impl UrlContentResolver {
         let content = get_request_body_text(&self.client, request).await?;
 
         let input_content = InputContent {
-            source: InputSource::RemoteUrl(Box::new(url.clone())),
+            source: ResolvedInputSource::RemoteUrl(Box::new(url.clone())),
             file_type,
             content,
         };

--- a/lychee-lib/src/types/resolver.rs
+++ b/lychee-lib/src/types/resolver.rs
@@ -1,9 +1,9 @@
-use super::{FileType, InputContent, InputSource};
+use super::{FileType, InputContent};
+use crate::types::input::source::ResolvedInputSource;
 use crate::utils::request;
 use crate::{BasicAuthExtractor, ErrorKind, Result, Uri};
 use http::HeaderMap;
 use reqwest::{Client, Request, Url};
-use crate::types::input::source::ResolvedInputSource;
 
 /// Structure to fetch remote content.
 #[derive(Debug, Default, Clone)]

--- a/lychee-lib/src/types/resolver.rs
+++ b/lychee-lib/src/types/resolver.rs
@@ -1,5 +1,4 @@
-use super::{FileType, InputContent};
-use crate::types::input::source::ResolvedInputSource;
+use super::{FileType, InputContent, ResolvedInputSource};
 use crate::utils::request;
 use crate::{BasicAuthExtractor, ErrorKind, Result, Uri};
 use http::HeaderMap;

--- a/lychee-lib/src/types/response.rs
+++ b/lychee-lib/src/types/response.rs
@@ -4,6 +4,7 @@ use http::StatusCode;
 use serde::Serialize;
 
 use crate::{InputSource, Status, Uri};
+use crate::types::ResolvedInputSource;
 
 /// Response type returned by lychee after checking a URI
 //
@@ -14,13 +15,13 @@ use crate::{InputSource, Status, Uri};
 // `pub(crate)` is insufficient, because the `stats` module is in the `bin`
 // crate crate.
 #[derive(Debug)]
-pub struct Response(InputSource, pub ResponseBody);
+pub struct Response(ResolvedInputSource, pub ResponseBody);
 
 impl Response {
     #[inline]
     #[must_use]
     /// Create new response
-    pub const fn new(uri: Uri, status: Status, source: InputSource) -> Self {
+    pub const fn new(uri: Uri, status: Status, source: ResolvedInputSource) -> Self {
         Response(source, ResponseBody { uri, status })
     }
 
@@ -35,7 +36,7 @@ impl Response {
     #[must_use]
     /// Retrieve the underlying source of the response
     /// (e.g. the input file or the URL)
-    pub const fn source(&self) -> &InputSource {
+    pub const fn source(&self) -> &ResolvedInputSource {
         &self.0
     }
 

--- a/lychee-lib/src/types/response.rs
+++ b/lychee-lib/src/types/response.rs
@@ -3,8 +3,7 @@ use std::fmt::Display;
 use http::StatusCode;
 use serde::Serialize;
 
-use crate::types::ResolvedInputSource;
-use crate::{Status, Uri};
+use crate::{ResolvedInputSource, Status, Uri};
 
 /// Response type returned by lychee after checking a URI
 //

--- a/lychee-lib/src/types/response.rs
+++ b/lychee-lib/src/types/response.rs
@@ -3,8 +3,8 @@ use std::fmt::Display;
 use http::StatusCode;
 use serde::Serialize;
 
-use crate::{InputSource, Status, Uri};
 use crate::types::ResolvedInputSource;
+use crate::{Status, Uri};
 
 /// Response type returned by lychee after checking a URI
 //

--- a/lychee-lib/src/utils/request.rs
+++ b/lychee-lib/src/utils/request.rs
@@ -304,7 +304,7 @@ mod tests {
     #[test]
     fn test_relative_url_resolution_from_root_dir() {
         let root_dir = PathBuf::from("/tmp/lychee");
-        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"));
+        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"), None);
 
         let uris = vec![RawUri::from("relative.html")];
         let requests = create(uris, &source, Some(&root_dir), None, None);
@@ -320,7 +320,7 @@ mod tests {
     #[test]
     fn test_absolute_url_resolution_from_root_dir() {
         let root_dir = PathBuf::from("/tmp/lychee");
-        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"));
+        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"), None);
 
         let uris = vec![RawUri::from("https://another.com/page")];
         let requests = create(uris, &source, Some(&root_dir), None, None);
@@ -336,7 +336,7 @@ mod tests {
     #[test]
     fn test_root_relative_url_resolution_from_root_dir() {
         let root_dir = PathBuf::from("/tmp/lychee");
-        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"));
+        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"), None);
 
         let uris = vec![RawUri::from("/root-relative")];
         let requests = create(uris, &source, Some(&root_dir), None, None);
@@ -352,7 +352,7 @@ mod tests {
     #[test]
     fn test_parent_directory_url_resolution_from_root_dir() {
         let root_dir = PathBuf::from("/tmp/lychee");
-        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"));
+        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"), None);
 
         let uris = vec![RawUri::from("../parent")];
         let requests = create(uris, &source, Some(&root_dir), None, None);
@@ -368,7 +368,7 @@ mod tests {
     #[test]
     fn test_fragment_url_resolution_from_root_dir() {
         let root_dir = PathBuf::from("/tmp/lychee");
-        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"));
+        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"), None);
 
         let uris = vec![RawUri::from("#fragment")];
         let requests = create(uris, &source, Some(&root_dir), None, None);
@@ -385,7 +385,7 @@ mod tests {
     fn test_relative_url_resolution_from_root_dir_and_base_url() {
         let root_dir = PathBuf::from("/tmp/lychee");
         let base = Base::try_from("https://example.com/path/page.html").unwrap();
-        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"));
+        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"), None);
 
         let uris = vec![RawUri::from("relative.html")];
         let requests = create(uris, &source, Some(&root_dir), Some(&base), None);
@@ -402,7 +402,7 @@ mod tests {
     fn test_absolute_url_resolution_from_root_dir_and_base_url() {
         let root_dir = PathBuf::from("/tmp/lychee");
         let base = Base::try_from("https://example.com/path/page.html").unwrap();
-        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"));
+        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"), None);
 
         let uris = vec![RawUri::from("https://another.com/page")];
         let requests = create(uris, &source, Some(&root_dir), Some(&base), None);
@@ -419,7 +419,7 @@ mod tests {
     fn test_root_relative_url_resolution_from_root_dir_and_base_url() {
         let root_dir = PathBuf::from("/tmp/lychee");
         let base = Base::try_from("https://example.com/path/page.html").unwrap();
-        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"));
+        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"), None);
 
         let uris = vec![RawUri::from("/root-relative")];
         let requests = create(uris, &source, Some(&root_dir), Some(&base), None);
@@ -436,7 +436,7 @@ mod tests {
     fn test_parent_directory_url_resolution_from_root_dir_and_base_url() {
         let root_dir = PathBuf::from("/tmp/lychee");
         let base = Base::try_from("https://example.com/path/page.html").unwrap();
-        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"));
+        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"), None);
 
         let uris = vec![RawUri::from("../parent")];
         let requests = create(uris, &source, Some(&root_dir), Some(&base), None);
@@ -453,7 +453,7 @@ mod tests {
     fn test_fragment_url_resolution_from_root_dir_and_base_url() {
         let root_dir = PathBuf::from("/tmp/lychee");
         let base = Base::try_from("https://example.com/path/page.html").unwrap();
-        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"));
+        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"), None);
 
         let uris = vec![RawUri::from("#fragment")];
         let requests = create(uris, &source, Some(&root_dir), Some(&base), None);
@@ -484,7 +484,7 @@ mod tests {
     #[test]
     fn test_create_request_from_relative_file_path() {
         let base = Base::Local(PathBuf::from("/tmp/lychee"));
-        let input_source = ResolvedInputSource::FsPath(PathBuf::from("page.html"));
+        let input_source = ResolvedInputSource::FsPath(PathBuf::from("page.html"), None);
 
         let actual = create_request(
             &RawUri::from("file.html"),
@@ -512,7 +512,8 @@ mod tests {
     #[test]
     fn test_create_request_from_absolute_file_path() {
         let base = Base::Local(PathBuf::from("/tmp/lychee"));
-        let input_source = ResolvedInputSource::FsPath(PathBuf::from("/tmp/lychee/page.html"));
+        let input_source =
+            ResolvedInputSource::FsPath(PathBuf::from("/tmp/lychee/page.html"), None);
 
         // Use an absolute path that's outside the base directory
         let actual = create_request(

--- a/lychee-lib/src/utils/request.rs
+++ b/lychee-lib/src/utils/request.rs
@@ -140,7 +140,7 @@ pub(crate) fn create(
     base: Option<&Base>,
     extractor: Option<&BasicAuthExtractor>,
 ) -> HashSet<Request> {
-    let base = base.cloned().or_else(|| Base::from_source(&source));
+    let base = base.cloned().or_else(|| Base::from_source(source));
 
     uris.into_iter()
         .filter_map(|raw_uri| {

--- a/lychee-lib/src/utils/request.rs
+++ b/lychee-lib/src/utils/request.rs
@@ -64,7 +64,7 @@ fn try_parse_into_uri(
                 None => return Err(ErrorKind::InvalidBaseJoin(text.clone())),
             },
             None => match source {
-                ResolvedInputSource::FsPath(root, _) => {
+                ResolvedInputSource::FsPath(root) => {
                     create_uri_from_file_path(root, &text, root_dir.is_none())?
                 }
                 _ => return Err(ErrorKind::UnsupportedUriType(text)),
@@ -304,7 +304,7 @@ mod tests {
     #[test]
     fn test_relative_url_resolution_from_root_dir() {
         let root_dir = PathBuf::from("/tmp/lychee");
-        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"), None);
+        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"));
 
         let uris = vec![RawUri::from("relative.html")];
         let requests = create(uris, &source, Some(&root_dir), None, None);
@@ -320,7 +320,7 @@ mod tests {
     #[test]
     fn test_absolute_url_resolution_from_root_dir() {
         let root_dir = PathBuf::from("/tmp/lychee");
-        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"), None);
+        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"));
 
         let uris = vec![RawUri::from("https://another.com/page")];
         let requests = create(uris, &source, Some(&root_dir), None, None);
@@ -336,7 +336,7 @@ mod tests {
     #[test]
     fn test_root_relative_url_resolution_from_root_dir() {
         let root_dir = PathBuf::from("/tmp/lychee");
-        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"), None);
+        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"));
 
         let uris = vec![RawUri::from("/root-relative")];
         let requests = create(uris, &source, Some(&root_dir), None, None);
@@ -352,7 +352,7 @@ mod tests {
     #[test]
     fn test_parent_directory_url_resolution_from_root_dir() {
         let root_dir = PathBuf::from("/tmp/lychee");
-        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"), None);
+        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"));
 
         let uris = vec![RawUri::from("../parent")];
         let requests = create(uris, &source, Some(&root_dir), None, None);
@@ -368,7 +368,7 @@ mod tests {
     #[test]
     fn test_fragment_url_resolution_from_root_dir() {
         let root_dir = PathBuf::from("/tmp/lychee");
-        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"), None);
+        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"));
 
         let uris = vec![RawUri::from("#fragment")];
         let requests = create(uris, &source, Some(&root_dir), None, None);
@@ -385,7 +385,7 @@ mod tests {
     fn test_relative_url_resolution_from_root_dir_and_base_url() {
         let root_dir = PathBuf::from("/tmp/lychee");
         let base = Base::try_from("https://example.com/path/page.html").unwrap();
-        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"), None);
+        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"));
 
         let uris = vec![RawUri::from("relative.html")];
         let requests = create(uris, &source, Some(&root_dir), Some(&base), None);
@@ -402,7 +402,7 @@ mod tests {
     fn test_absolute_url_resolution_from_root_dir_and_base_url() {
         let root_dir = PathBuf::from("/tmp/lychee");
         let base = Base::try_from("https://example.com/path/page.html").unwrap();
-        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"), None);
+        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"));
 
         let uris = vec![RawUri::from("https://another.com/page")];
         let requests = create(uris, &source, Some(&root_dir), Some(&base), None);
@@ -419,7 +419,7 @@ mod tests {
     fn test_root_relative_url_resolution_from_root_dir_and_base_url() {
         let root_dir = PathBuf::from("/tmp/lychee");
         let base = Base::try_from("https://example.com/path/page.html").unwrap();
-        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"), None);
+        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"));
 
         let uris = vec![RawUri::from("/root-relative")];
         let requests = create(uris, &source, Some(&root_dir), Some(&base), None);
@@ -436,7 +436,7 @@ mod tests {
     fn test_parent_directory_url_resolution_from_root_dir_and_base_url() {
         let root_dir = PathBuf::from("/tmp/lychee");
         let base = Base::try_from("https://example.com/path/page.html").unwrap();
-        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"), None);
+        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"));
 
         let uris = vec![RawUri::from("../parent")];
         let requests = create(uris, &source, Some(&root_dir), Some(&base), None);
@@ -453,7 +453,7 @@ mod tests {
     fn test_fragment_url_resolution_from_root_dir_and_base_url() {
         let root_dir = PathBuf::from("/tmp/lychee");
         let base = Base::try_from("https://example.com/path/page.html").unwrap();
-        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"), None);
+        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"));
 
         let uris = vec![RawUri::from("#fragment")];
         let requests = create(uris, &source, Some(&root_dir), Some(&base), None);
@@ -484,7 +484,7 @@ mod tests {
     #[test]
     fn test_create_request_from_relative_file_path() {
         let base = Base::Local(PathBuf::from("/tmp/lychee"));
-        let input_source = ResolvedInputSource::FsPath(PathBuf::from("page.html"), None);
+        let input_source = ResolvedInputSource::FsPath(PathBuf::from("page.html"));
 
         let actual = create_request(
             &RawUri::from("file.html"),
@@ -513,7 +513,7 @@ mod tests {
     fn test_create_request_from_absolute_file_path() {
         let base = Base::Local(PathBuf::from("/tmp/lychee"));
         let input_source =
-            ResolvedInputSource::FsPath(PathBuf::from("/tmp/lychee/page.html"), None);
+            ResolvedInputSource::FsPath(PathBuf::from("/tmp/lychee/page.html"));
 
         // Use an absolute path that's outside the base directory
         let actual = create_request(

--- a/lychee-lib/src/utils/request.rs
+++ b/lychee-lib/src/utils/request.rs
@@ -512,8 +512,7 @@ mod tests {
     #[test]
     fn test_create_request_from_absolute_file_path() {
         let base = Base::Local(PathBuf::from("/tmp/lychee"));
-        let input_source =
-            ResolvedInputSource::FsPath(PathBuf::from("/tmp/lychee/page.html"));
+        let input_source = ResolvedInputSource::FsPath(PathBuf::from("/tmp/lychee/page.html"));
 
         // Use an absolute path that's outside the base directory
         let actual = create_request(

--- a/lychee-lib/src/utils/request.rs
+++ b/lychee-lib/src/utils/request.rs
@@ -6,13 +6,13 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use crate::types::ResolvedInputSource;
 use crate::{
     Base, BasicAuthCredentials, ErrorKind, Request, Result, Uri,
     basic_auth::BasicAuthExtractor,
     types::{InputSource, uri::raw::RawUri},
     utils::{path, url},
 };
-use crate::types::ResolvedInputSource;
 
 /// Extract basic auth credentials for a given URL.
 pub(crate) fn extract_credentials(

--- a/lychee-lib/src/utils/request.rs
+++ b/lychee-lib/src/utils/request.rs
@@ -6,11 +6,10 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::types::ResolvedInputSource;
 use crate::{
     Base, BasicAuthCredentials, ErrorKind, Request, Result, Uri,
     basic_auth::BasicAuthExtractor,
-    types::{InputSource, uri::raw::RawUri},
+    types::{InputSource, ResolvedInputSource, uri::raw::RawUri},
     utils::{path, url},
 };
 
@@ -141,8 +140,8 @@ pub(crate) fn create(
     base: Option<&Base>,
     extractor: Option<&BasicAuthExtractor>,
 ) -> HashSet<Request> {
-    let x: InputSource = source.clone().into();
-    let base = base.cloned().or_else(|| Base::from_source(&x));
+    let input_source: InputSource = source.clone().into();
+    let base = base.cloned().or_else(|| Base::from_source(&input_source));
 
     uris.into_iter()
         .filter_map(|raw_uri| {

--- a/lychee-lib/src/utils/request.rs
+++ b/lychee-lib/src/utils/request.rs
@@ -9,7 +9,7 @@ use std::{
 use crate::{
     Base, BasicAuthCredentials, ErrorKind, Request, Result, Uri,
     basic_auth::BasicAuthExtractor,
-    types::{InputSource, ResolvedInputSource, uri::raw::RawUri},
+    types::{ResolvedInputSource, uri::raw::RawUri},
     utils::{path, url},
 };
 
@@ -140,8 +140,7 @@ pub(crate) fn create(
     base: Option<&Base>,
     extractor: Option<&BasicAuthExtractor>,
 ) -> HashSet<Request> {
-    let input_source: InputSource = source.clone().into();
-    let base = base.cloned().or_else(|| Base::from_source(&input_source));
+    let base = base.cloned().or_else(|| Base::from_source(&source));
 
     uris.into_iter()
         .filter_map(|raw_uri| {
@@ -225,7 +224,7 @@ mod tests {
     #[test]
     fn test_relative_url_resolution() {
         let base = Base::try_from("https://example.com/path/page.html").unwrap();
-        let source = InputSource::String(String::new());
+        let source = ResolvedInputSource::String(String::new());
 
         let uris = vec![RawUri::from("relative.html")];
         let requests = create(uris, &source, None, Some(&base), None);
@@ -241,7 +240,7 @@ mod tests {
     #[test]
     fn test_absolute_url_resolution() {
         let base = Base::try_from("https://example.com/path/page.html").unwrap();
-        let source = InputSource::String(String::new());
+        let source = ResolvedInputSource::String(String::new());
 
         let uris = vec![RawUri::from("https://another.com/page")];
         let requests = create(uris, &source, None, Some(&base), None);
@@ -257,7 +256,7 @@ mod tests {
     #[test]
     fn test_root_relative_url_resolution() {
         let base = Base::try_from("https://example.com/path/page.html").unwrap();
-        let source = InputSource::String(String::new());
+        let source = ResolvedInputSource::String(String::new());
 
         let uris = vec![RawUri::from("/root-relative")];
         let requests = create(uris, &source, None, Some(&base), None);
@@ -273,7 +272,7 @@ mod tests {
     #[test]
     fn test_parent_directory_url_resolution() {
         let base = Base::try_from("https://example.com/path/page.html").unwrap();
-        let source = InputSource::String(String::new());
+        let source = ResolvedInputSource::String(String::new());
 
         let uris = vec![RawUri::from("../parent")];
         let requests = create(uris, &source, None, Some(&base), None);
@@ -289,7 +288,7 @@ mod tests {
     #[test]
     fn test_fragment_url_resolution() {
         let base = Base::try_from("https://example.com/path/page.html").unwrap();
-        let source = InputSource::String(String::new());
+        let source = ResolvedInputSource::String(String::new());
 
         let uris = vec![RawUri::from("#fragment")];
         let requests = create(uris, &source, None, Some(&base), None);
@@ -305,7 +304,7 @@ mod tests {
     #[test]
     fn test_relative_url_resolution_from_root_dir() {
         let root_dir = PathBuf::from("/tmp/lychee");
-        let source = InputSource::FsPath(PathBuf::from("/some/page.html"));
+        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"));
 
         let uris = vec![RawUri::from("relative.html")];
         let requests = create(uris, &source, Some(&root_dir), None, None);
@@ -321,7 +320,7 @@ mod tests {
     #[test]
     fn test_absolute_url_resolution_from_root_dir() {
         let root_dir = PathBuf::from("/tmp/lychee");
-        let source = InputSource::FsPath(PathBuf::from("/some/page.html"));
+        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"));
 
         let uris = vec![RawUri::from("https://another.com/page")];
         let requests = create(uris, &source, Some(&root_dir), None, None);
@@ -337,7 +336,7 @@ mod tests {
     #[test]
     fn test_root_relative_url_resolution_from_root_dir() {
         let root_dir = PathBuf::from("/tmp/lychee");
-        let source = InputSource::FsPath(PathBuf::from("/some/page.html"));
+        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"));
 
         let uris = vec![RawUri::from("/root-relative")];
         let requests = create(uris, &source, Some(&root_dir), None, None);
@@ -353,7 +352,7 @@ mod tests {
     #[test]
     fn test_parent_directory_url_resolution_from_root_dir() {
         let root_dir = PathBuf::from("/tmp/lychee");
-        let source = InputSource::FsPath(PathBuf::from("/some/page.html"));
+        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"));
 
         let uris = vec![RawUri::from("../parent")];
         let requests = create(uris, &source, Some(&root_dir), None, None);
@@ -369,7 +368,7 @@ mod tests {
     #[test]
     fn test_fragment_url_resolution_from_root_dir() {
         let root_dir = PathBuf::from("/tmp/lychee");
-        let source = InputSource::FsPath(PathBuf::from("/some/page.html"));
+        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"));
 
         let uris = vec![RawUri::from("#fragment")];
         let requests = create(uris, &source, Some(&root_dir), None, None);
@@ -386,7 +385,7 @@ mod tests {
     fn test_relative_url_resolution_from_root_dir_and_base_url() {
         let root_dir = PathBuf::from("/tmp/lychee");
         let base = Base::try_from("https://example.com/path/page.html").unwrap();
-        let source = InputSource::FsPath(PathBuf::from("/some/page.html"));
+        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"));
 
         let uris = vec![RawUri::from("relative.html")];
         let requests = create(uris, &source, Some(&root_dir), Some(&base), None);
@@ -403,7 +402,7 @@ mod tests {
     fn test_absolute_url_resolution_from_root_dir_and_base_url() {
         let root_dir = PathBuf::from("/tmp/lychee");
         let base = Base::try_from("https://example.com/path/page.html").unwrap();
-        let source = InputSource::FsPath(PathBuf::from("/some/page.html"));
+        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"));
 
         let uris = vec![RawUri::from("https://another.com/page")];
         let requests = create(uris, &source, Some(&root_dir), Some(&base), None);
@@ -420,7 +419,7 @@ mod tests {
     fn test_root_relative_url_resolution_from_root_dir_and_base_url() {
         let root_dir = PathBuf::from("/tmp/lychee");
         let base = Base::try_from("https://example.com/path/page.html").unwrap();
-        let source = InputSource::FsPath(PathBuf::from("/some/page.html"));
+        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"));
 
         let uris = vec![RawUri::from("/root-relative")];
         let requests = create(uris, &source, Some(&root_dir), Some(&base), None);
@@ -437,7 +436,7 @@ mod tests {
     fn test_parent_directory_url_resolution_from_root_dir_and_base_url() {
         let root_dir = PathBuf::from("/tmp/lychee");
         let base = Base::try_from("https://example.com/path/page.html").unwrap();
-        let source = InputSource::FsPath(PathBuf::from("/some/page.html"));
+        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"));
 
         let uris = vec![RawUri::from("../parent")];
         let requests = create(uris, &source, Some(&root_dir), Some(&base), None);
@@ -454,7 +453,7 @@ mod tests {
     fn test_fragment_url_resolution_from_root_dir_and_base_url() {
         let root_dir = PathBuf::from("/tmp/lychee");
         let base = Base::try_from("https://example.com/path/page.html").unwrap();
-        let source = InputSource::FsPath(PathBuf::from("/some/page.html"));
+        let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"));
 
         let uris = vec![RawUri::from("#fragment")];
         let requests = create(uris, &source, Some(&root_dir), Some(&base), None);
@@ -469,7 +468,7 @@ mod tests {
 
     #[test]
     fn test_no_base_url_resolution() {
-        let source = InputSource::String(String::new());
+        let source = ResolvedInputSource::String(String::new());
 
         let uris = vec![RawUri::from("https://example.com/page")];
         let requests = create(uris, &source, None, None, None);
@@ -485,7 +484,7 @@ mod tests {
     #[test]
     fn test_create_request_from_relative_file_path() {
         let base = Base::Local(PathBuf::from("/tmp/lychee"));
-        let input_source = InputSource::FsPath(PathBuf::from("page.html"));
+        let input_source = ResolvedInputSource::FsPath(PathBuf::from("page.html"));
 
         let actual = create_request(
             &RawUri::from("file.html"),
@@ -513,7 +512,7 @@ mod tests {
     #[test]
     fn test_create_request_from_absolute_file_path() {
         let base = Base::Local(PathBuf::from("/tmp/lychee"));
-        let input_source = InputSource::FsPath(PathBuf::from("/tmp/lychee/page.html"));
+        let input_source = ResolvedInputSource::FsPath(PathBuf::from("/tmp/lychee/page.html"));
 
         // Use an absolute path that's outside the base directory
         let actual = create_request(


### PR DESCRIPTION
for parts of the link checking pipeline including and downstream of `InputContent`, this PR replaces `InputSource` fields with `ResolvedInputSource`. specifically, this means the structs `InputContent`, `Request`, and `Response`. 

this makes sense for two reasons:
- conceptually, once you are able to read the content of a source, you must have resolved globs to a real path, so using ResolvedInputSource is more accurate.
- in practice, InputContent's source field was never set to a FsGlob variant, it always used variant cases which are shared with ResolvedInputSource. this is because InputContent was constructed by [pattern matching out of a ResolvedInputSource](https://github.com/lycheeverse/lychee/blob/be26d02c80825bb485ec504f39787a0df6310a34/lychee-lib/src/types/input/input.rs#L208-L221) - also see the `*_content` methods in that code snippet. so there is no loss of information in making this PR, it is just a more precise type.

in particular, the second point above means this can be done with no changes to external behaviour (there is a breaking API change, of course). in fact, this PR is almost a direct text replacement, with the gain in line count only happening because of new multi-line expressions.

this PR is motivated because when working with relative URLs and base URLs, it would be nice to know that the FsGlob case is excluded, as it would be impossible to construct a URL relative to a glob.

i've tried to make this PR reasonably through in its replacement of usages but notably, the stats maps are still `HashMap<InputSource, ...>` rather than ResolvedInputSource. i tried to change this and it led to a can of worms with InputSource implementing Deserialize but ResolvedInputSource doesn't, so i abandoned it. so, we simply convert ResolvedInputSource back to InputSource before making the statistics.